### PR TITLE
Momentumの式の誤修正の復元とbiasの修正

### DIFF
--- a/Layer.cpp
+++ b/Layer.cpp
@@ -45,7 +45,7 @@ std::vector<std::vector<double>> Layers::Dense::forward(std::vector<std::vector<
                 t+=i[k]*neuron[j][k];
             }
 
-            t-=bias[j];
+            t+=bias[j];
 
             res.push_back(t);
         }

--- a/Model.cpp
+++ b/Model.cpp
@@ -145,7 +145,7 @@ std::vector<double> NNModel::fit(int step, double learning_rate, std::vector<std
                         layer.neuron[i][j] -= learning_rate * layer_grad[i][j] * (1 / (sqrt(layer.h_layer[i][j] + 1e-7)));
                     }
                     else if(m_optimizer == "Momentum"){
-                        layer.v_layer[i][j] = Momentum_alpha * layer.v_layer[i][j] + learning_rate * layer_grad[i][j];
+                        layer.v_layer[i][j] = Momentum_alpha * layer.v_layer[i][j] - learning_rate * layer_grad[i][j];
                         layer.neuron[i][j] += layer.v_layer[i][j];
                     }
                     else if(m_optimizer == "Adam"){
@@ -170,7 +170,7 @@ std::vector<double> NNModel::fit(int step, double learning_rate, std::vector<std
                     layer.bias[i] -= learning_rate * bias_grad[i] * (1 / (sqrt(layer.h_bias[i] + 1e-7)));
                 }
                 else if(m_optimizer == "Momentum"){
-                    layer.v_bias[i] = Momentum_alpha * layer.v_bias[i] + learning_rate * bias_grad[i];
+                    layer.v_bias[i] = Momentum_alpha * layer.v_bias[i] - learning_rate * bias_grad[i];
                     layer.bias[i] += layer.v_bias[i];
                 }
                 else if(m_optimizer == "Adam"){


### PR DESCRIPTION
・Momentumの式の誤修正の復元
元の式が正しかったのにも関わらず、1回目のPull requestで謎の誤修正をしてしまいました、ごめんなさい...
・biasの修正
biasが減算されていたのを加算に変更しました。
[元となっている記事](https://qiita.com/Luke02561/items/ee98d6e742febef04731)のバイアスの勾配に負符号がついていなかったので、これで正しくなると思います。
また、検証用に書いたsin(x)の学習が良い感じになった(元ではたまに誤差が発散した)のでこれで大丈夫なはずです。
```cpp
#include "Model.hpp"
#include "bits/stdc++.h"

using namespace std;
inline double rand(double lef,double rig){
  static random_device rng;
  return double(rng())/UINT_MAX*(rig-lef)+lef;
}
int main(){
  vector<vector<double>> x(1000000,vector<double>(1)),y = x;
  for(int i=0;i<1000000;i++){
    x[i][0] = rand(0,1);
    y[i][0] = sin(x[i][0]);
  }
  int time = clock();
  NNModel model(1);
  model.AddDenseLayer(10,ActivationType::Sigmoid);
  model.AddDenseLayer(1,ActivationType::Linear);
  model.compile("Adam");
  vector<vector<vector<double>>> w;vector<vector<double>> b;
  model.fit(1000000,0.01,x,y,1,"mse");
  cout << "Training Time:" << clock()-time << endl;
  vector<vector<double>> x2(10,vector<double>(1));
  for(int i=0;i<10;i++){
    x2[i][0] = rand(0,1);
  }
  auto res = model.predict(x2);
  for(int i=0;i<10;i++) cout << x2[i][0] << " " << res[i][0] << " " << sin(x2[i][0]) << endl;
}

```